### PR TITLE
Remove full-stops in the screenshot caption

### DIFF
--- a/src/main/resources/metadata/com.toxicstoxm.ledsuite.appdata.xml
+++ b/src/main/resources/metadata/com.toxicstoxm.ledsuite.appdata.xml
@@ -135,15 +135,15 @@
   <launchable type="desktop-id">com.toxicstoxm.ledsuite.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <caption>LEDSuite add file dialog, used to upload files to the backend.</caption>
+      <caption>LEDSuite add file dialog, used to upload files to the backend</caption>
       <image>https://www.toxicstoxm.com/LEDSuite/metadata/screenshots/LEDSuite-AddFileDialog.png</image>
     </screenshot>
     <screenshot>
-      <caption>Example of what the settings menu of an animation can look like.</caption>
+      <caption>Example of what the settings menu of an animation can look like</caption>
       <image>https://www.toxicstoxm.com/LEDSuite/metadata/screenshots/LEDSuite-AnimationSettingsDialog.png</image>
     </screenshot>
     <screenshot>
-      <caption>LEDSuite settings menu.</caption>
+      <caption>LEDSuite settings menu</caption>
       <image>https://www.toxicstoxm.com/LEDSuite/metadata/screenshots/LEDSuite-SettingsDialog.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
To comply with flathub specification